### PR TITLE
Improve productionization of TurfWar

### DIFF
--- a/src/.init.lua
+++ b/src/.init.lua
@@ -1,9 +1,20 @@
+sqlite3 = require "lsqlite3"
+
 function IntToIPString(n)
     return string.format("%d.%d.%d.%d",
         (n >> 24) & 255,
         (n >> 16) & 255,
         (n >> 8) & 255,
         (n >> 0) & 255)
+end
+
+function ConnectDb()
+    if not db then
+        db = sqlite3.open("db.sqlite3")
+        db:busy_timeout(1000)
+        db:exec[[PRAGMA journal_mode=WAL]]
+        db:exec[[PRAGMA synchronous=NORMAL]]
+    end
 end
 
 -- Redbean's global route handler
@@ -21,14 +32,10 @@ function OnHttpRequest()
     end
 end
 
--- Setup() isn't called by the server,
--- you just call it yourself in the
--- redbean REPL
-function Setup()
-    local sqlite3 = require "lsqlite3"
-    local db = sqlite3.open("db.sqlite3", sqlite3.OPEN_READWRITE + sqlite3.OPEN_CREATE)
+function OnServerStart()
+    ConnectDb()
     local res = db:exec[[
-        CREATE TABLE "land" (
+        CREATE TABLE IF NOT EXISTS "land" (
             ip INTEGER PRIMARY KEY,
             nick TEXT NOT NULL CHECK (length(nick) = 8),
             created_at TEXT DEFAULT (STRFTIME('%Y-%m-%d %H:%M:%f', 'NOW'))
@@ -39,4 +46,6 @@ function Setup()
     else
         print(db:errmsg())
     end
+    db:close()
+    db = nil
 end

--- a/src/claim.lua
+++ b/src/claim.lua
@@ -13,9 +13,7 @@ elseif re.search([[^[a-zA-Z0-9]{8}$]], name) ~= name then
     SetStatus(400)
     Write("Name must be ASCII alphanumeric")
 else
-    local sqlite3 = require "lsqlite3"
-    local db = sqlite3.open("db.sqlite3", sqlite3.OPEN_READWRITE)
-    db:exec[[PRAGMA writable_schema=ON]] -- until redbean supports strict
+    ConnectDb()
     local stmt = db:prepare([[
         INSERT INTO land (ip, nick) VALUES (?1, ?2)
         ON CONFLICT (ip) DO UPDATE SET (nick) = (?2)

--- a/src/summary.lua
+++ b/src/summary.lua
@@ -29,9 +29,7 @@ else
     biggest = 0xFFFFFFFF
 end
 
-local sqlite3 = require "lsqlite3"
-local db = sqlite3.open("db.sqlite3", sqlite3.OPEN_READONLY)
-db:exec[[PRAGMA writable_schema=ON]] -- until redbean supports strict
+ConnectDb()
 local stmt = db:prepare([[
     SELECT nick, COUNT(ip) as score FROM land WHERE ip >= ?1 AND ip <= ?2 GROUP BY nick;
 ]])


### PR DESCRIPTION
This change helps TurfWar handle 420k qps of read traffic.

```
main jart@nightmare:~/vendor/turfwar$ wrk -t 12 -c 120 http://10.10.10.124:8080/
Running 10s test @ http://10.10.10.124:8080/
  12 threads and 120 connections
  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency   380.99us    5.13ms 210.87ms   99.72%
    Req/Sec    35.45k    20.32k  118.37k    68.99%
  4253968 requests in 10.10s, 11.74GB read
Requests/sec: 421152.43
Transfer/sec:      1.16GB
```