### PR TITLE
Fix pluralization logic in user.html

### DIFF
--- a/src/user.html
+++ b/src/user.html
@@ -34,7 +34,7 @@
                     const li = document.createElement('li');
                     const ranking = 1 + Object.values(score).filter(b => (b.find(([k,v]) => k == block) || [null,0])[1] > count).length;
                     const tied = Object.values(score).filter(b => (b.find(([k,v]) => k == block) || [null,0])[1] === count).length > 1;
-                    li.innerText = `${tied?'Tied ':''}${ordinal(ranking)} in block ${block}.0.0.0/8 with ${Intl.NumberFormat().format(count)} address${total == 1 ? '' : 'es'}`
+                    li.innerText = `${tied?'Tied ':''}${ordinal(ranking)} in block ${block}.0.0.0/8 with ${Intl.NumberFormat().format(count)} address${count == 1 ? '' : 'es'}`
                     ul.appendChild(li);
                     total += count;
                 }


### PR DESCRIPTION
Small grammar change :) The pluralization in the per-block leadership rank entries on the page for users is being done based on the running total that's been tallied up so far instead of based on the number of addresses claimed in each block, causing things like this:

![image](https://github.com/shamblesides/turfwar/assets/49729978/8b3e368d-3b8e-42d8-9a12-f75e90d4a0c1)

